### PR TITLE
Fix 20% share percentage (and corrected B&M name)

### DIFF
--- a/samples/1830-Papers.xxp
+++ b/samples/1830-Papers.xxp
@@ -5,7 +5,7 @@ company:
     B&M:
       _:
         long_name_text_text: |
-            Baltimore & Maine
+            Boston & Maine
         short_name_text_text: B&M
         token_1_text_text: Free
         token_2_text_text: $40

--- a/xxpaper/XXP_company.xxp
+++ b/xxpaper/XXP_company.xxp
@@ -464,7 +464,7 @@ company:
           text: 2 Shares
         share_desc_text:
           suppress: False
-        share_ptc_text:
+        share_pct_text:
           text: 20%
         token_1_embed:
           suppress: True


### PR DESCRIPTION
share_pct_text was misspelled share_ptc_text
