### PR TITLE
Add option for paper scaling

### DIFF
--- a/xxpaper/page.py
+++ b/xxpaper/page.py
@@ -48,6 +48,9 @@ class Page (object):
       self._end_page ()
     print "StartPage"
     self.canvas.saveState ()
+    x_scale = Config.get ("user/x_scale", {"default": 1})
+    y_scale = Config.get ("user/y_scale", {"default": 1})
+    self.canvas.scale (x_scale, y_scale)
     x_adjust = Config.get ("user/%s_x_adjust" % typ, {"default": None})
     y_adjust = Config.get ("user/%s_y_adjust" % typ, {"default": None})
     nomark = Config.get ("DEFAULT/no_registration", {"default": []})


### PR DESCRIPTION
Add scale option to .xxpaperrc to be used for adjusting printer errors.

My current printer needs a small compensation length wise because the print ends up being just slightly too large... which is highly visible when using the die cutter. (y_scale: 0.996)

Seems like an easy option to have in a printer driver, but so far I haven't found a way to "fix" the problem in a general way.