### PR TITLE
Add concession to XXP_company

### DIFF
--- a/xxpaper/XXP_company.xxp
+++ b/xxpaper/XXP_company.xxp
@@ -104,6 +104,20 @@ company:
     _include_:
       - XXP_company_share_objects.xxp
 
+  concession:
+ 
+    CUT_ELEMENT: cutline_box
+
+    ELEMENTS: ${TEMPLATE_concession_default/.}
+
+    index:
+
+    cutline_box: ${DEFAULT/asset_tile}
+
+    _include_:
+      - XXP_company_concession_objects.xxp
+
+
   token:
 
     index:


### PR DESCRIPTION
So I had the following error:

`CRITICAL:logtool.log_fault_impl:FAULT: /usr/local/lib/python3.6/dist-packages/xxpaper-1.1.post3-py3.6.egg/xxpaper/main.py(51): KeyError('Not found: concession/index',)
Something broke!`

Adding concession to `XXP_company.xxp` fixed that problem.