### PR TITLE
Add missing outline_circles to templates_embed

### DIFF
--- a/xxpaper/XXP_token_objects.xxp
+++ b/xxpaper/XXP_token_objects.xxp
@@ -118,6 +118,7 @@ TEMPLATE_stripey_embed:
   - bottom_line_box
   - name_stripe_box
   - short_name_text
+  - outline_circle
 
 TEMPLATE_stripey_cross:
   - token_interior_box
@@ -137,6 +138,7 @@ TEMPLATE_stripey_cross_embed:
   - vertical_stripe_box
   - name_stripe_box
   - short_name_text
+  - outline_circle
 
 TEMPLATE_triple_up:
   - token_interior_box
@@ -154,6 +156,7 @@ TEMPLATE_triple_up_embed:
   - inner_circle
   - name_stripe_box
   - short_name_text
+  - outline_circle
 
 TEMPLATE_wedges:
   - token_interior_box


### PR DESCRIPTION
4 of token `TEMPLATE_*_embed` were missing `outline_circles`.